### PR TITLE
Applies gain and other small detector modifications

### DIFF
--- a/UVEX/UVIM_DET.yaml
+++ b/UVEX/UVIM_DET.yaml
@@ -18,6 +18,7 @@ properties:
   image_plane_id: 0
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
+  gain: 1.2
 
 effects:
   - name: UVEX_Detector
@@ -58,7 +59,7 @@ effects:
     description: CMOS detector dark current
     class: DarkCurrent
     kwargs:
-      value: 0.003 # [e-/s]
+      value: 0.001 # [e-/s]
 
   - name: detector_linearity
     description: Detector linearity and saturation characteristics
@@ -83,10 +84,20 @@ effects:
     include: False
     kwargs:
       filename: tbd_ipc_kernel.fits
-
-  - name: reference_pixel_border
-    description: Reference pixel border handling (optional; detector-specific)
-    class: ReferencePixelBorder
-    include: False
+    
+  - name: ad_conversion
+    description: Apply gain and convert electron count into integers
+    class: ADConversion
     kwargs:
-      n_border: 4
+       dtype: uint16
+       gain:
+           1:  "!DET.gain"
+           2:  "!DET.gain"
+           3:  "!DET.gain"
+           4:  "!DET.gain"
+           5:  "!DET.gain"
+           6:  "!DET.gain"
+           7:  "!DET.gain"
+           8:  "!DET.gain"
+           9:  "!DET.gain"
+

--- a/UVEX/UVIM_DET_LSS.yaml
+++ b/UVEX/UVIM_DET_LSS.yaml
@@ -16,6 +16,7 @@ properties:
   image_plane_id: 0
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
+  gain: 1.2
 
 effects:
   - name: LSS_Detector
@@ -38,26 +39,49 @@ effects:
       pixsize_unit: mm
       angle_unit: deg
       gain_unit: electron/adu
+      
+#  - name: bias
+#    description: Constant electronic bias offset added to the readout
+#    class: Bias
+#    kwargs:
+#      value: 0
 
-  - name: dark_current
+  - name: lss_dark_current
     description: CMOS detector dark current
     class: DarkCurrent
     # [e-/s] level of dark current for each detector
     kwargs:
       value: 0.001
 
-#  - name: detector_linearity
-#    description: Linearity characteristics of H4RG chips
-#    class: LinearityCurve
-#    kwargs:
-#      filename: tbd.dat
+  - name: lss_detector_linearity
+    description: Detector linearity and saturation characteristics
+    class: LinearityCurve
+    include: False
+    kwargs:
+      filename: tbd_det_linearity.dat
 
-  - name: shot_noise
+  - name: lss_shot_noise
     description: apply poisson shot noise to images
     class: ShotNoise
 
-  - name: readout_noise
+  - name: lss_readout_noise
     description: Readout noise frames
     class: BasicReadoutNoise
     kwargs:
       noise_std: 2.0 # e-
+
+  - name: lss_inter_pixel_capacitance
+    description: Inter-pixel capacitance (IPC) convolution kernel
+    class: InterPixelCapacitance
+    include: False
+    kwargs:
+      filename: tbd_ipc_kernel.fits
+      
+  - name: lss_ad_conversion
+    description: Apply gain and convert electron count into integers
+    class: ADConversion
+    kwargs:
+       dtype: uint16
+       gain:
+           1:  "!DET.gain"
+           2:  "!DET.gain"


### PR DESCRIPTION
Adds the ADConversion effect. This applies the gain (currently as defined in 'properties' at the top of the detector YAML files - at some point we'll need to update ScopeSim to look at the detector-specific values in DetectorList). 

This results in an unsigned integer image output, which is what we expect to receive from the detectors themselves. You can then retrieve an image in electron units by converting to float and multiplying by the gain.

Also brought the LSS and imager detectors in line with each other and gave unique names to the LSS effects to prevent confusion. 