### PR TITLE
Add config-driven LSS detector layout generation

### DIFF
--- a/UVEX/UVIM_DET_LSS.yaml
+++ b/UVEX/UVIM_DET_LSS.yaml
@@ -7,6 +7,7 @@
 # - 2026-03-23 (HE) Added metadata
 # - 2026-04-06 (ES) Swapped spectral and spatial directions
 # - 2026-04-13 (ES) Added off-sky position for use with slit, updated detector gap size
+# - 2026-05-18 (OA) Implemented a data file for the coordinates of the detectors
 
 object: detector
 alias: DET
@@ -28,15 +29,7 @@ effects:
       # Shift detector FoV center on-sky for off-axis LSS channel
       fov_x_cen: 12600.0  # arcsec
       fov_y_cen: 0.0 # arcsec
-      array_dict:
-        id: [1, 2]
-        pixsize: [0.01, 0.01] # 10 microns / pix
-        angle: [0., 0.]
-        gain: [1.2, 1.2]
-        y_cen: [0., 0.]
-        x_cen: [-5.874, 35.702] # two detectors oriented along the spectral direction
-        y_size: [40.96, 40.96]
-        x_size: [40.96, 40.96]
+      filename: data_files/UVIM_DET_LSS_layout.dat
       x_cen_unit: mm
       y_cen_unit: mm
       x_size_unit: mm

--- a/UVEX/code/make_inputs.py
+++ b/UVEX/code/make_inputs.py
@@ -53,14 +53,26 @@ class UVEXInputs:
         self.slit_width = u.Quantity(config['lss']['slit_width'])
         self.lss_pixel_scale = u.Quantity(config['lss']['pixel_scale'])
         self.lss_plate_scale = self.lss_pixel_scale / self.pix_size
-        
+
         # Make LSS inputs
         self.make_slit_geometry()
         self.make_spectral_efficiency(infile=config['lss']['spectral_efficiency_file'])
         self.make_spectral_trace(indir=config['lss']['detector_psf_dir'])
         self.make_dispersion_file(infile=config['lss']['dispersion_file'])
         self.make_lss_filter_response(infile=config['lss']['filter_file'])
-        
+
+        # Load LSS detector parameters
+        self.lss_n_pixels = config['lss_detector']['n_pixels']
+        self.lss_pix_size = u.Quantity(config['lss_detector']['pix_size'])
+        self.lss_x_gap = u.Quantity(config['lss_detector']['x_gap'])
+        self.lss_gain = u.Quantity(config['lss_detector']['gain'])
+        self.lss_angle = u.Quantity(config['lss_detector']['angle'])
+        self.lss_x1_cen = u.Quantity(config['lss_detector']['x1_cen'])
+        self.lss_y1_cen = u.Quantity(config['lss_detector']['y1_cen'])
+
+        # Make LSS detector layout
+        self.make_detector_layout_lss()
+                
     def make_reflectivity(self, infile="mirror_reflectivity.dat", outfile="mirror_reflectivity.dat"):
         # For now, straight up copy the file over
         # We'll make a parser once new technical data comes in
@@ -308,6 +320,50 @@ class UVEXInputs:
                         f"{names[i][j]}\n"
                     )
                     det_id += 1
+
+    def make_detector_layout_lss(self, outfile="UVIM_DET_LSS_layout.dat"):
+        # active detector size in mm
+        det_size = (self.lss_n_pixels * self.lss_pix_size).to(u.mm).value
+
+        # only x-gap is used for LSS
+        gx = self.lss_x_gap.to(u.mm).value
+
+        # per-detector values
+        pixsize = self.lss_pix_size.to(u.mm).value
+        gain = self.lss_gain.to(u.electron / u.adu).value
+        angle = self.lss_angle.to(u.deg).value
+
+        # preserve off-center placement of LSS1 from config
+        x1 = self.lss_x1_cen.to(u.mm).value
+        y1 = self.lss_y1_cen.to(u.mm).value
+
+        # LSS2 is placed to the right of LSS1 by detector width + gap
+        x2 = x1 + det_size + gx
+        y2 = y1
+
+        names = ["LSS1", "LSS2"]
+        centers = [(x1, y1), (x2, y2)]
+
+        with open(os.path.join(self.outputs_dir, outfile), "w") as f:
+            f.write("# author: O. Adegoke\n")
+            f.write("# sources:\n")
+            f.write("# date_created: 2026-05-18\n")
+            f.write(f"# date_modified: {np.datetime64('today', 'D').astype(str)}\n")
+            f.write("\n")
+            f.write("id    x_cen       y_cen     x_size   y_size     pixsize  angle  gain   name\n")
+
+            for det_id, ((x, y), name) in enumerate(zip(centers, names), start=1):
+                f.write(
+                    f"{det_id:>2d}   "
+                    f"{x:>8.4f}   "
+                    f"{y:>8.4f}   "
+                    f"{det_size:>6.2f}   "
+                    f"{det_size:>6.2f}   "
+                    f"{pixsize:>7.2f}   "
+                    f"{angle:>5.1f}   "
+                    f"{gain:>5.2f}   "
+                    f"{name}\n"
+                )
         
     def make_contamination(self, thickness_infile="contam_thickness.csv", coeff_infile="contam_absorption_coeff.txt", stage='eol'):
         # load thickness file and num film passes to dict on component by component basis

--- a/UVEX/config.yaml
+++ b/UVEX/config.yaml
@@ -53,5 +53,12 @@ lss:
     gap_size: 100
     pixel_scale: 0.80 arcsec
 
-
+lss_detector:
+    n_pixels: 4096
+    pix_size: 0.01 mm
+    x_gap: 0.616 mm
+    gain: 1.2 electron/adu
+    angle: 0.0 deg
+    x1_cen: -5.874 mm
+    y1_cen: 0.0 mm
 

--- a/UVEX/data_files/UVIM_DET_LSS_layout.dat
+++ b/UVEX/data_files/UVIM_DET_LSS_layout.dat
@@ -1,0 +1,8 @@
+# author: O. Adegoke
+# sources:
+# date_created: 2026-05-18
+# date_modified: 2026-05-18
+
+id    x_cen       y_cen     x_size   y_size     pixsize  angle  gain   name
+ 1    -5.8740     0.0000    40.96    40.96      0.01     0.0    1.20   LSS1
+ 2    35.7020     0.0000    40.96    40.96      0.01     0.0    1.20   LSS2


### PR DESCRIPTION
## Summary
- add config-driven inputs for LSS detector layout
- update "make_inputs.py" to generate "data_files/UVIM_DET_LSS_layout.dat"
- update "UVIM_DET_LSS.yaml" to reference the generated layout file
- add the generated "UVIM_DET_LSS_layout.dat"

## Notes
- preserves off-center placement for LSS_DET1
- computes LSS_DET2 x-center from detector width + configured x-gap