### PR TITLE
Extend LSS response to 365 nm

### DIFF
--- a/UVEX/code/make_inputs.py
+++ b/UVEX/code/make_inputs.py
@@ -53,6 +53,8 @@ class UVEXInputs:
         self.slit_width = u.Quantity(config['lss']['slit_width'])
         self.lss_pixel_scale = u.Quantity(config['lss']['pixel_scale'])
         self.lss_plate_scale = self.lss_pixel_scale / self.pix_size
+        self.lss_wave_min = u.Quantity(config['lss']['wave_min'])
+        self.lss_wave_max = u.Quantity(config['lss']['wave_max'])
         
         # Make LSS inputs
         self.make_slit_geometry()
@@ -174,6 +176,10 @@ class UVEXInputs:
         data = np.loadtxt(os.path.join(self.inputs_dir, infile), skiprows=1, unpack=True, delimiter=",")
         wavelength = data[0] * u.nm
         transmission = data[1] / 100.0 # convert from percentage to fraction
+        
+        if wavelength[-1] < self.lss_wave_max:
+            wavelength = np.append(wavelength, self.lss_wave_max)
+            transmission = np.append(transmission, transmission[-1])
 
         with open(os.path.join(self.outputs_dir, outfile), 'w') as f:
             f.write(f"# date_modified : {np.datetime64('today', 'D').astype(str)}\n")

--- a/UVEX/config.yaml
+++ b/UVEX/config.yaml
@@ -44,6 +44,9 @@ lss:
     
     slit_length: 3600 arcsec
     slit_width: 2 arcsec
+    
+    wave_min: 115 nm
+    wave_max: 365 nm
 
     spectral_efficiency_file: "zeiss_blaze_v1.txt"
     dispersion_file: "UVEXS_Spectral_Resolution_R2000.txt"

--- a/UVEX/data_files/UVIM_LSS_filter_response.dat
+++ b/UVEX/data_files/UVIM_LSS_filter_response.dat
@@ -1,4 +1,4 @@
-# date_modified : 2026-03-23
+# date_modified : 2026-05-19
 # orig_filename: graded_overcoat_00nm.csv
 # wavelength_unit: nm
 wavelength    transmission
@@ -21,3 +21,4 @@ wavelength    transmission
 265.0    0.716548
 285.0    0.691579
 305.0    0.626997
+365.0    0.626997


### PR DESCRIPTION
Alters the LSS filter response curve generation to extend response up to 365 nm as a constant so we can see behavior at high wavelengths (this is currently how it's done in the ETC as well while we await an updated curve). 