### PR TITLE
Adds Si band gap and dummy linearity curve

### DIFF
--- a/UVEX/UVIM_DET.yaml
+++ b/UVEX/UVIM_DET.yaml
@@ -1,11 +1,12 @@
 # author : Hannah Earnshaw
 # date_created : 2026-01-28
-# date_modified : 2026-03-23
+# date_modified : 2026-06-12
 # status : development
 # changes :
 # - 2026-01-28 (HE) Created file
 # - 2026-03-05 (OA) Created detector array and added effects
 # - 2026-03-23 (HE) Added metadata
+# - 2026-06-12 (HE) Added linearity and Si bandgap
 
 object: detector
 alias: DET
@@ -42,6 +43,12 @@ effects:
 #    kwargs:
 #      value: 0
 
+  - name: si_bandgap
+    description: Si band gap at ~1.1 um
+    class: QuantumEfficiencyCurve
+    kwargs:
+      filename: data_files/Si_bandgap.dat
+
   - name: dark_current
     description: CMOS detector dark current
     class: DarkCurrent
@@ -51,9 +58,8 @@ effects:
   - name: detector_linearity
     description: Detector linearity and saturation characteristics
     class: LinearityCurve
-    include: False
     kwargs:
-      filename: tbd_det_linearity.dat
+      filename: data_files/UVIM_DET_linearity.dat
 
   - name: shot_noise
     description: Apply poisson shot noise to images

--- a/UVEX/UVIM_DET_LSS.yaml
+++ b/UVEX/UVIM_DET_LSS.yaml
@@ -1,6 +1,6 @@
 # author : Evangela Shread
 # date_created : 2026-01-28
-# date_modified : 2026-04-13
+# date_modified : 2026-06-12
 # status : development
 # changes :
 # - 2026-02-12 (ES) Created file
@@ -9,6 +9,7 @@
 # - 2026-04-13 (ES) Added off-sky position for use with slit, updated detector gap size
 # - 2026-05-18 (OA) Implemented a data file for the coordinates of the detectors
 # - 2026-05-26 (ES) Reference instrument properties for detector center in sky coordinates
+# - 2026-06-12 (HE) Added linearity and Si bandgap
 
 object: detector
 alias: DET
@@ -44,6 +45,12 @@ effects:
 #    kwargs:
 #      value: 0
 
+  - name: si_bandgap
+    description: Si band gap at ~1.1 um
+    class: QuantumEfficiencyCurve
+    kwargs:
+      filename: data_files/Si_bandgap.dat
+
   - name: lss_dark_current
     description: CMOS detector dark current
     class: DarkCurrent
@@ -54,9 +61,8 @@ effects:
   - name: lss_detector_linearity
     description: Detector linearity and saturation characteristics
     class: LinearityCurve
-    include: False
     kwargs:
-      filename: tbd_det_linearity.dat
+      filename: data_files/UVIM_DET_linearity.dat
 
   - name: lss_shot_noise
     description: apply poisson shot noise to images

--- a/UVEX/data_files/Si_bandgap.dat
+++ b/UVEX/data_files/Si_bandgap.dat
@@ -1,0 +1,7 @@
+# date_modified : 2026-06-12
+# wavelength_unit: um
+wavelength    transmission
+0.100    1.000000
+1.000    1.000000
+1.107    0.000000
+9.999    0.000000

--- a/UVEX/data_files/UVIM_DET_linearity.dat
+++ b/UVEX/data_files/UVIM_DET_linearity.dat
@@ -1,0 +1,20 @@
+# name : UVEX linearity curve
+# author : Hannah Earnshaw
+# date_created : 2026-06-12
+# date_modified : 2026-06-12
+# type : detector:linearity
+# incident_unit : e
+# measured_unit : e
+#
+# changes :
+# - 2026-06-12 (HE) dummy curve to get us started
+#
+incident    measured
+0           0
+1           1
+100         100
+1000        1000
+5000        5000
+10000       10000
+15000       15000
+1e19        15000


### PR DESCRIPTION
Adds a Si band gap (will be incorporated into measured Q.E. curves in the future anyway but works as a blunt tool to cut off anything that might be around above 1.1 µm).

Also adds a dummy linearity curve that is linear up to an approximation of the high-gain saturation limit. 