### PR TITLE
Bring imager output in line with ETC

### DIFF
--- a/UVEX/UVEX.yaml
+++ b/UVEX/UVEX.yaml
@@ -15,6 +15,8 @@ description: The Ultraviolet Explorer telescope common optics
 properties:
   temperature: 0
   telescope: UVEX
+  area: 0.4417865
+  area_unit: m2
 
 effects:
   - name: ota_surface_list

--- a/UVEX/UVIM_DET.yaml
+++ b/UVEX/UVIM_DET.yaml
@@ -93,4 +93,9 @@ effects:
            7:  "!DET.gain"
            8:  "!DET.gain"
            9:  "!DET.gain"
+    
+  - name: exposure
+    description: Expose for given exposure time DIT
+    class: ExposureIntegration
+
 

--- a/UVEX/UVIM_DET_LSS.yaml
+++ b/UVEX/UVIM_DET_LSS.yaml
@@ -93,3 +93,7 @@ effects:
        gain:
            1:  "!DET.gain"
            2:  "!DET.gain"
+    
+  - name: lss_exposure
+    description: Expose for given exposure time DIT
+    class: ExposureIntegration


### PR DESCRIPTION
Difference between instrument simulator and ETC output for the imager was caused by a combination of incorrect telescope area and readout not being performed for the provided exposure time. These have now been fixed by the addition of a telescope area property and an ExposureIntegration effect.