### PR TITLE
Re-ordering effects in YAMLs

### DIFF
--- a/UVEX/UVEX.yaml
+++ b/UVEX/UVEX.yaml
@@ -19,12 +19,6 @@ properties:
   area_unit: m2
 
 effects:
-  - name: ota_surface_list
-    description: list of surfaces in UVEX OTA
-    class: SurfaceList
-    kwargs:
-      filename: LIST_mirrors_OTA.tbl
-
   - name: spacecraft_pointing
     description: Blurring due to spacecraft pointing jitter
     class: SpacecraftPointing
@@ -32,6 +26,12 @@ effects:
     kwargs:
       fwhm: 2
       fwhm_unit: arcsec
+      
+  - name: ota_surface_list
+    description: list of surfaces in UVEX OTA
+    class: SurfaceList
+    kwargs:
+      filename: LIST_mirrors_OTA.tbl
 
 ---
 alias: ATMO

--- a/UVEX/UVIM_DET.yaml
+++ b/UVEX/UVIM_DET.yaml
@@ -37,17 +37,15 @@ effects:
 
   # QE is intentionally NOT included here (handled separately for NUV and FUV)
 
-#  - name: bias
-#    description: Constant electronic bias offset added to the readout
-#    class: Bias
-#    kwargs:
-#      value: 0
-
   - name: si_bandgap
     description: Si band gap at ~1.1 um
     class: QuantumEfficiencyCurve
     kwargs:
       filename: data_files/Si_bandgap.dat
+
+  - name: exposure
+    description: Expose for given exposure time DIT
+    class: ExposureIntegration
 
   - name: dark_current
     description: CMOS detector dark current
@@ -55,21 +53,15 @@ effects:
     kwargs:
       value: 0.001 # [e-/s]
 
+  - name: shot_noise
+    description: Apply poisson shot noise to images
+    class: ShotNoise
+
   - name: detector_linearity
     description: Detector linearity and saturation characteristics
     class: LinearityCurve
     kwargs:
       filename: data_files/UVIM_DET_linearity.dat
-
-  - name: shot_noise
-    description: Apply poisson shot noise to images
-    class: ShotNoise
-
-  - name: readout_noise
-    description: Readout noise frames
-    class: BasicReadoutNoise
-    kwargs:
-      noise_std: 3
 
   - name: inter_pixel_capacitance
     description: Inter-pixel capacitance (IPC) convolution kernel
@@ -77,7 +69,19 @@ effects:
     include: False
     kwargs:
       filename: tbd_ipc_kernel.fits
-    
+
+#  - name: bias
+#    description: Constant electronic bias offset added to the readout
+#    class: Bias
+#    kwargs:
+#      value: 0
+
+  - name: readout_noise
+    description: Readout noise frames
+    class: BasicReadoutNoise
+    kwargs:
+      noise_std: 3
+
   - name: ad_conversion
     description: Apply gain and convert electron count into integers
     class: ADConversion
@@ -93,9 +97,6 @@ effects:
            7:  "!DET.gain"
            8:  "!DET.gain"
            9:  "!DET.gain"
-    
-  - name: exposure
-    description: Expose for given exposure time DIT
-    class: ExposureIntegration
+
 
 

--- a/UVEX/UVIM_DET_LSS.yaml
+++ b/UVEX/UVIM_DET_LSS.yaml
@@ -38,18 +38,16 @@ effects:
       pixsize_unit: mm
       angle_unit: deg
       gain_unit: electron/adu
-      
-#  - name: bias
-#    description: Constant electronic bias offset added to the readout
-#    class: Bias
-#    kwargs:
-#      value: 0
 
   - name: si_bandgap
     description: Si band gap at ~1.1 um
     class: QuantumEfficiencyCurve
     kwargs:
       filename: data_files/Si_bandgap.dat
+
+  - name: lss_exposure
+    description: Expose for given exposure time DIT
+    class: ExposureIntegration
 
   - name: lss_dark_current
     description: CMOS detector dark current
@@ -59,16 +57,29 @@ effects:
     kwargs:
       value: 0.001
 
+  - name: lss_shot_noise
+    description: apply poisson shot noise to images
+    class: ShotNoise
+    include: True
+
   - name: lss_detector_linearity
     description: Detector linearity and saturation characteristics
     class: LinearityCurve
     kwargs:
       filename: data_files/UVIM_DET_linearity.dat
 
-  - name: lss_shot_noise
-    description: apply poisson shot noise to images
-    class: ShotNoise
-    include: True
+  - name: lss_inter_pixel_capacitance
+    description: Inter-pixel capacitance (IPC) convolution kernel
+    class: InterPixelCapacitance
+    include: False
+    kwargs:
+      filename: tbd_ipc_kernel.fits
+
+#  - name: bias
+#    description: Constant electronic bias offset added to the readout
+#    class: Bias
+#    kwargs:
+#      value: 0
 
   - name: lss_readout_noise
     description: Readout noise frames
@@ -77,13 +88,6 @@ effects:
     kwargs:
       noise_std: 2.0 # e-
 
-  - name: lss_inter_pixel_capacitance
-    description: Inter-pixel capacitance (IPC) convolution kernel
-    class: InterPixelCapacitance
-    include: False
-    kwargs:
-      filename: tbd_ipc_kernel.fits
-      
   - name: lss_ad_conversion
     description: Apply gain and convert electron count into integers
     class: ADConversion
@@ -93,7 +97,4 @@ effects:
        gain:
            1:  "!DET.gain"
            2:  "!DET.gain"
-    
-  - name: lss_exposure
-    description: Expose for given exposure time DIT
-    class: ExposureIntegration
+

--- a/UVEX/UVIM_FUV.yaml
+++ b/UVEX/UVIM_FUV.yaml
@@ -15,17 +15,17 @@ properties:
   plate_scale: 103   # arcsec / mm
 
 effects:
-  - name: fuv_surfaces
-    description: surfaces list for FUV imaging, including the filter and dichroic transmission
-    class: SurfaceList
-    kwargs:
-      filename: LIST_surfaces_FUV.tbl
-
   - name: psf
     class: SeeingPSF
     kwargs:
       fwhm: 2
       fwhm_unit: arcsec
+
+  - name: fuv_surfaces
+    description: surfaces list for FUV imaging, including the filter and dichroic transmission
+    class: SurfaceList
+    kwargs:
+      filename: LIST_surfaces_FUV.tbl
 
 # No QE curve required as the filter is directly on the detector and thus incorporates QE
 

--- a/UVEX/UVIM_LSS.yaml
+++ b/UVEX/UVIM_LSS.yaml
@@ -24,6 +24,24 @@ properties:
   fov_unit: arcsec
 
 effects:
+  - name: oversample_image
+    description: oversample the image in the spatial directions for subpixel accuracy
+    class: Oversample
+    include: True
+
+  - name: slit_psf
+    description: PSF at the slit
+    class: SlitPSF
+    include: True
+    kwargs:
+      directory: "LSS_SLIT_PSF"
+
+  - name: slit_geometry
+    description: slit geometry on the focal plane
+    class: UVEXSlitMask
+    kwargs:
+      filename: "data_files/UVIM_LSS_slit_geometry.dat"
+
   - name: relay_optics
     description: list of extra mirrors needed for the spectroscopy mode
     class: SurfaceList
@@ -36,11 +54,12 @@ effects:
     kwargs:
       filename: "data_files/UVIM_LSS_spectral_efficiency.fits"
 
-  - name: slit_geometry
-    description: slit geometry on the focal plane
-    class: UVEXSlitMask
+  - name: spectral_traces
+    description: spectral trace geometry on the focal plane
+    class: SpectralTraceList
     kwargs:
-      filename: "data_files/UVIM_LSS_slit_geometry.dat"
+      filename: "data_files/UVIM_LSS_spectral_trace.fits"
+      dispersion_file: "data_files/UVIM_LSS_dispersion.dat"
 
   - name : surfaces
     description : surfaces list for the spectroscopy mode
@@ -54,25 +73,6 @@ effects:
     include: True
     kwargs:
       directory: "LSS_DET_PSF"
-      
-  - name: slit_psf
-    description: PSF at the slit
-    class: SlitPSF
-    include: True
-    kwargs:
-      directory: "LSS_SLIT_PSF"
-
-  - name: spectral_traces 
-    description: spectral trace geometry on the focal plane
-    class: SpectralTraceList
-    kwargs:
-      filename: "data_files/UVIM_LSS_spectral_trace.fits"
-      dispersion_file: "data_files/UVIM_LSS_dispersion.dat"
-
-  - name: oversample_image
-    description: oversample the image in the spatial directions for subpixel accuracy
-    class: Oversample
-    include: True
 
   - name: downsample_image
     description: downsample the image to native pixel resolution after it has been oversampled

--- a/UVEX/UVIM_NUV.yaml
+++ b/UVEX/UVIM_NUV.yaml
@@ -16,17 +16,17 @@ properties:
   plate_scale: 103   # arcsec / mm
 
 effects:
-  - name: nuv_surfaces
-    description: surfaces list for NUV imaging, including the filter and dichroic transmission
-    class: SurfaceList
-    kwargs:
-      filename: LIST_surfaces_NUV.tbl
-
   - name: psf
     class: SeeingPSF
     kwargs:
       fwhm: 2
       fwhm_unit: arcsec
+
+  - name: nuv_surfaces
+    description: surfaces list for NUV imaging, including the filter and dichroic transmission
+    class: SurfaceList
+    kwargs:
+      filename: LIST_surfaces_NUV.tbl
 
   - name: qe_curve
     description: Quantum efficiency curve for the NUV detector


### PR DESCRIPTION
I think I've identified the issue with our weirdly high noise. I noticed that the detector effects were getting applied in a nonsensical order. Apparently, this is because while effects are sorted into z-order groupings by the 100s digit, the order within that grouping doesn't have any physical reality, and we're supposed to put effects in the config files in the order they should be applied.

At some point in development, I think we reactivated effect sorting within a z-order, which doesn't make physical sense, particularly for detector effects. What we need to do instead is turn off that sorting and make sure that effects are defined in the correct order in the YAML files. 

I've gone through the YAML files and put them in what I think is the correct order. @evangelashread if you could double-check this, especially when it comes to the LSS components. @okadegoke, you may also need to check on whether this affects your vignetting/PSF implementations.